### PR TITLE
Improve/Fix Undo Redo

### DIFF
--- a/ATSketchKit.xcodeproj/xcshareddata/xcschemes/ATSketchKitDemo.xcscheme
+++ b/ATSketchKit.xcodeproj/xcshareddata/xcschemes/ATSketchKitDemo.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "89C20FFF1C2CDF5D001DF73B"
-               BuildableName = "ATSketchKitDemo.app"
+               BuildableName = "Sketchalicious.app"
                BlueprintName = "ATSketchKitDemo"
                ReferencedContainer = "container:ATSketchKit.xcodeproj">
             </BuildableReference>
@@ -43,7 +43,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "89C20FFF1C2CDF5D001DF73B"
-            BuildableName = "ATSketchKitDemo.app"
+            BuildableName = "Sketchalicious.app"
             BlueprintName = "ATSketchKitDemo"
             ReferencedContainer = "container:ATSketchKit.xcodeproj">
          </BuildableReference>
@@ -66,7 +66,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "89C20FFF1C2CDF5D001DF73B"
-            BuildableName = "ATSketchKitDemo.app"
+            BuildableName = "Sketchalicious.app"
             BlueprintName = "ATSketchKitDemo"
             ReferencedContainer = "container:ATSketchKit.xcodeproj">
          </BuildableReference>
@@ -85,7 +85,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "89C20FFF1C2CDF5D001DF73B"
-            BuildableName = "ATSketchKitDemo.app"
+            BuildableName = "Sketchalicious.app"
             BlueprintName = "ATSketchKitDemo"
             ReferencedContainer = "container:ATSketchKit.xcodeproj">
          </BuildableReference>

--- a/ATSketchKit/ATSketchView+Events.swift
+++ b/ATSketchKit/ATSketchView+Events.swift
@@ -30,7 +30,7 @@ extension ATSketchView {
 			return
 		}
 
-    self.clearRedo()
+    self.flushRedoHistory()
 		
 		if event != nil {
 		}

--- a/ATSketchKit/ATSketchView+Events.swift
+++ b/ATSketchKit/ATSketchView+Events.swift
@@ -29,6 +29,8 @@ extension ATSketchView {
 			NSLog("No touches")
 			return
 		}
+
+    self.clearRedo()
 		
 		if event != nil {
 		}

--- a/ATSketchKit/ATSketchView+LayerManagement.swift
+++ b/ATSketchKit/ATSketchView+LayerManagement.swift
@@ -33,7 +33,7 @@ extension ATSketchView {
 		newShapeLayer.fillColor = nil
 		newShapeLayer.contentsScale = UIScreen.mainScreen().scale
 		self.layer.insertSublayer(newShapeLayer, below: self.topLayer)
-    self.delegate?.sketchViewUndoRedoUpdated(self)
+    self.delegate?.sketchViewUpdatedUndoRedoState(self)
 		newShapeLayer.setNeedsDisplay()
 	}
 	

--- a/ATSketchKit/ATSketchView+LayerManagement.swift
+++ b/ATSketchKit/ATSketchView+LayerManagement.swift
@@ -33,6 +33,7 @@ extension ATSketchView {
 		newShapeLayer.fillColor = nil
 		newShapeLayer.contentsScale = UIScreen.mainScreen().scale
 		self.layer.insertSublayer(newShapeLayer, below: self.topLayer)
+    self.delegate?.sketchViewUndoRedoUpdated(self)
 		newShapeLayer.setNeedsDisplay()
 	}
 	

--- a/ATSketchKit/ATSketchView+UndoRedo.swift
+++ b/ATSketchKit/ATSketchView+UndoRedo.swift
@@ -32,6 +32,7 @@ extension ATSketchView {
 			mostRecentLayer!.removeFromSuperlayer()
 		}
 		self.setNeedsDisplay()
+    self.delegate?.sketchViewUndoRedoUpdated(self)
 	}
 	
 	public func redo() {
@@ -42,6 +43,7 @@ extension ATSketchView {
 			self.history.removeLast()
 		}
 		self.setNeedsDisplay()
+    self.delegate?.sketchViewUndoRedoUpdated(self)
 	}
 
   public func clearRedo() {

--- a/ATSketchKit/ATSketchView+UndoRedo.swift
+++ b/ATSketchKit/ATSketchView+UndoRedo.swift
@@ -32,7 +32,7 @@ extension ATSketchView {
 			mostRecentLayer!.removeFromSuperlayer()
 		}
 		self.setNeedsDisplay()
-    self.delegate?.sketchViewUndoRedoUpdated(self)
+    self.delegate?.sketchViewUpdatedUndoRedoState(self)
 	}
 	
 	public func redo() {
@@ -43,10 +43,10 @@ extension ATSketchView {
 			self.history.removeLast()
 		}
 		self.setNeedsDisplay()
-    self.delegate?.sketchViewUndoRedoUpdated(self)
+    self.delegate?.sketchViewUpdatedUndoRedoState(self)
 	}
 
-  public func clearRedo() {
+  public func flushRedoHistory() {
     self.history.removeAll()
   }
 }

--- a/ATSketchKit/ATSketchView+UndoRedo.swift
+++ b/ATSketchKit/ATSketchView+UndoRedo.swift
@@ -38,10 +38,13 @@ extension ATSketchView {
 		let mostRecentUndoLayer = self.history.last
 		
 		if mostRecentUndoLayer != nil {
-			self.layer.addSublayer(mostRecentUndoLayer!)
+      self.layer.insertSublayer(mostRecentUndoLayer!, below: self.topLayer)
 			self.history.removeLast()
 		}
 		self.setNeedsDisplay()
 	}
-	
+
+  public func clearRedo() {
+    self.history.removeAll()
+  }
 }

--- a/ATSketchKit/ATSketchView.swift
+++ b/ATSketchKit/ATSketchView.swift
@@ -84,8 +84,7 @@ public class ATSketchView: UIView {
 	
 	public var canUndo: Bool {
 		get {
-			return allowUndoRedo
-			// TODO: add here conditions based on the history stack
+      return allowUndoRedo && self.layer.sublayers?.count > 1
 		}
 	}
 	

--- a/ATSketchKitDemo/Base.lproj/Main.storyboard
+++ b/ATSketchKitDemo/Base.lproj/Main.storyboard
@@ -229,7 +229,9 @@
                         <outlet property="colorPicker" destination="Hhf-0v-d2i" id="LIj-ud-5V0"/>
                         <outlet property="controlPanel" destination="KiD-Ih-4KG" id="JeB-3n-Th4"/>
                         <outlet property="lineWidthSlider" destination="b1d-Uq-32R" id="Sbb-Km-xnS"/>
+                        <outlet property="redoButton" destination="GAB-mJ-v6G" id="19s-66-c73"/>
                         <outlet property="sketchView" destination="T2X-jH-LRF" id="bdJ-dU-8jj"/>
+                        <outlet property="undoButton" destination="d3Q-af-LJ6" id="NOB-Lf-cDw"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/ATSketchKitDemo/ViewController.swift
+++ b/ATSketchKitDemo/ViewController.swift
@@ -110,7 +110,7 @@ class ViewController: UIViewController, ATSketchViewDelegate, ATColorPickerDeleg
 		// We don't want to do anything here.
 	}
 
-  func sketchViewUndoRedoUpdated(sketchView: ATSketchView) {
+  func sketchViewUpdatedUndoRedoState(sketchView: ATSketchView) {
     undoButton.enabled = sketchView.canUndo
    redoButton.enabled = sketchView.canRedo
   }

--- a/ATSketchKitDemo/ViewController.swift
+++ b/ATSketchKitDemo/ViewController.swift
@@ -26,11 +26,14 @@ import ATSketchKit
 class ViewController: UIViewController, ATSketchViewDelegate, ATColorPickerDelegate {
 
 	@IBOutlet weak var sketchView: ATSketchView!
-    
+
 	@IBOutlet weak var controlPanel: ATControlPanelView!
 	@IBOutlet weak var colorPicker: ATColorPicker!
-    @IBOutlet weak var lineWidthSlider: UISlider!
-    @IBOutlet weak var brushButton: ATBrushButton!
+  @IBOutlet weak var lineWidthSlider: UISlider!
+  @IBOutlet weak var brushButton: ATBrushButton!
+
+  @IBOutlet weak var undoButton: UIButton!
+  @IBOutlet weak var redoButton: UIButton!
 
 	override func viewDidLoad() {
 		super.viewDidLoad()
@@ -50,6 +53,8 @@ class ViewController: UIViewController, ATSketchViewDelegate, ATColorPickerDeleg
         self.brushButton.selectedColor = self.sketchView.currentColor
         self.brushButton.selectedWidth = self.sketchView.currentLineWidth
         self.lineWidthSlider.value = Float(self.sketchView.currentLineWidth)
+        undoButton.enabled = sketchView.canUndo
+        redoButton.enabled = sketchView.canRedo
     }
 
 	// MARK: Tools controls
@@ -104,6 +109,11 @@ class ViewController: UIViewController, ATSketchViewDelegate, ATColorPickerDeleg
 	func sketchView(sketchView: ATSketchView, didRecognizePathWithName name: String) {
 		// We don't want to do anything here.
 	}
+
+  func sketchViewUndoRedoUpdated(sketchView: ATSketchView) {
+    undoButton.enabled = sketchView.canUndo
+   redoButton.enabled = sketchView.canRedo
+  }
 	
 	//MARK: - ATColorPickerDelegate
 	

--- a/ATSketchViewDelegate.swift
+++ b/ATSketchViewDelegate.swift
@@ -54,5 +54,5 @@ public protocol ATSketchViewDelegate {
 
   - Parameter sketchView: the view in which the undo/redo states were updated.
   */
-  func sketchViewUndoRedoUpdated(sketchView: ATSketchView)
+  func sketchViewUpdatedUndoRedoState(sketchView: ATSketchView)
 }

--- a/ATSketchViewDelegate.swift
+++ b/ATSketchViewDelegate.swift
@@ -48,4 +48,11 @@ public protocol ATSketchViewDelegate {
 	- Returns: nil if you wish not to override the drawing, otherwise a clean UIBezierPath
 	*/
 	func sketchViewOverridingRecognizedPathDrawing(sketchView: ATSketchView) -> UIBezierPath?
+
+  /**
+  Notifies the delegate that the canUndo and canRedo states have been updated.
+
+  - Parameter sketchView: the view in which the undo/redo states were updated.
+  */
+  func sketchViewUndoRedoUpdated(sketchView: ATSketchView)
 }


### PR DESCRIPTION
:green_heart: 
# Summary
- Redo history cleared after drawing action occurs.  Behavior now matches standard drawing program (gimp, photoshop, etc.) It makes no sense to go down the old behavior tree, when the user has already branched to a new one.
- Updated canUndo and canRedo boolean values
- Added delegate method for notification of canUndo and canRedo state changes
- Connected canUndo and canRedo to undo and redo buttons in demo app
